### PR TITLE
Pin har shard version to ~> 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ dependencies:
     github: hydecr/strange
   har:
     github: NeuraLegion/har
-    branch: master
+    version: ~> 1.0.0
 
 crystal: 0.24.1
 


### PR DESCRIPTION
Heads up: API is about the break, see https://github.com/NeuraLegion/har/pull/2