### PR TITLE
Fix window movement

### DIFF
--- a/src/marionette/types.cr
+++ b/src/marionette/types.cr
@@ -22,8 +22,13 @@ module Marionette
     include JSON::Serializable
   end
 
-  record Rect, height : Float64, width : Float64, x : Float64, y : Float64 do
+  struct Rect
     include JSON::Serializable
+
+    property height : Float64
+    property width : Float64
+    property x : Float64
+    property y : Float64
   end
 
   record Location, x : Float64, y : Float64 do

--- a/src/marionette/types.cr
+++ b/src/marionette/types.cr
@@ -22,13 +22,8 @@ module Marionette
     include JSON::Serializable
   end
 
-  struct Rect
+  record Rect, height : Float64, width : Float64, x : Float64, y : Float64 do
     include JSON::Serializable
-
-    property height : Float64
-    property width : Float64
-    property x : Float64
-    property y : Float64
   end
 
   record Location, x : Float64, y : Float64 do

--- a/src/marionette/window.cr
+++ b/src/marionette/window.cr
@@ -101,10 +101,7 @@ module Marionette
         if @handle != @session.current_window.handle
           Log.warn { "Only current window is supported for W3C Compatible browsers" }
         end
-        rect = self.rect
-        rect.x = position.x
-        rect.y = position.y
-        self.rect = rect
+        self.rect = rect.copy_with(x: position.x, y: position.y)
       else
         execute("SetWindowSize", {"x" => position.x, "y" => position.y})
       end

--- a/src/marionette/window.cr
+++ b/src/marionette/window.cr
@@ -111,7 +111,7 @@ module Marionette
     end
 
     def move_to(x, y)
-      position = Size.new(x: x.to_f, y: y.to_f)
+      position = Location.new(x: x.to_f, y: y.to_f)
       self.position = position
     end
 


### PR DESCRIPTION
Currently, the move_to() method doesn't even compile. This PR fixes those errors.

Small program to test the move_to fix:
```crystal
require "marionette"

window = Marionette::WebDriver.create_session(:chrome).current_window

loop do
  window.move_to(rand() * 300, rand() * 300)
  sleep 0.5
end
```