### PR TITLE
Fix Fullscreen

### DIFF
--- a/src/marionette/window.cr
+++ b/src/marionette/window.cr
@@ -125,7 +125,7 @@ module Marionette
     end
 
     def fullscreen
-      execute("FullScreenWindow")
+      execute("FullscreenWindow")
     end
 
     def execute(command, params = {} of String => String)


### PR DESCRIPTION
Why

Currently, when trying to make the current window fullscreen it throws exception

```bash
  Command FullScreenWindow not valid for browser Marionette::WebDriver (Exception)
         from lib/marionette/src/marionette/web_driver.cr:84:9 in 'execute'
         from lib/marionette/src/marionette/session.cr:833:16 in 'execute'
         from lib/marionette/src/marionette/window.cr:142:7 in 'execute'
         from lib/marionette/src/marionette/window.cr:134:5 in 'execute'
         from lib/marionette/src/marionette/window.cr:131:7 in 'fullscreen'
         from lib/flux/src/flux.cr:27:5 in 'fullscreen'
         from spec/flows/authorization_code_flux.cr:15:7 in 'call'
         from spec/flows/authorization_code_flux.cr:6:5 in 'flow'
         from spec/helpers/token_helper.cr:15:26 in 'prepare_code_challenge_url'
         from spec/token_spec.cr:11:45 in '->'
         from /usr/share/crystal/src/primitives.cr:266:3 in 'internal_run'
         from /usr/share/crystal/src/spec/example.cr:33:16 in 'run'
         from /usr/share/crystal/src/spec/context.cr:18:23 in 'internal_run'
         from /usr/share/crystal/src/spec/context.cr:330:7 in 'run'
         from /usr/share/crystal/src/spec/context.cr:18:23 in 'internal_run'
         from /usr/share/crystal/src/spec/context.cr:330:7 in 'run'
         from /usr/share/crystal/src/spec/context.cr:18:23 in 'internal_run'
         from /usr/share/crystal/src/spec/context.cr:147:7 in 'run'
         from /usr/share/crystal/src/spec/dsl.cr:201:7 in '->'
         from /usr/share/crystal/src/primitives.cr:266:3 in 'run'
         from /usr/share/crystal/src/crystal/main.cr:45:14 in 'main'
         from /usr/share/crystal/src/crystal/main.cr:119:3 in 'main'
         from __libc_start_main
         from _start
         from ???
```

Side Effects

When calling `current_window.fullscreen` no exception is thrown and windows is resize to full screen.