### PR TITLE
Adds Rescue to At_Exit handler

### DIFF
--- a/src/marionette/session.cr
+++ b/src/marionette/session.cr
@@ -22,8 +22,11 @@ module Marionette
                    @service = nil,
                    @w3c = false)
       at_exit do
-        if (svc = @service) && !svc.closed?
-          stop
+        begin
+          if (svc = @service) && !svc.closed?
+            stop
+          end
+        rescue
         end
       end
     end


### PR DESCRIPTION
# Why

When using Marionette to run specs the `at_exit` runs and causes the specs to be recorded as failed.

The changes proposed will not produce side effects when running specs

### Actual

```bash
 AZU   Fri 11/12/2021 10:21:12 ⤑   Debug  ⤑  Crystal-run-spec.tmp ⤑  [572µs] COMMIT
2021-11-12T22:21:12.046360Z  DEBUG - clear: [572µs] COMMIT
..........

Finished in 1:03 minutes
10 examples, 0 failures, 0 errors, 0 pending
Error running at_exit handler: Tried to run command without establishing a connection
Error running at_exit handler: Tried to run command without establishing a connection
Error running at_exit handler: Tried to run command without establishing a connection
Error: Process completed with exit code 1.
```

### Expected

```bash
 AZU   Fri 11/12/2021 10:21:12 ⤑   Debug  ⤑  Crystal-run-spec.tmp ⤑  [572µs] COMMIT
2021-11-12T22:21:12.046360Z  DEBUG - clear: [572µs] COMMIT
..........

Finished in 1:03 minutes
10 examples, 0 failures, 0 errors, 0 pending
```

## Alternatives

I do not understand the benefits of the `at_exit` handler and it might be better to remove it and leave this to be handled by the application using the library

```crystal
at_exit do
        begin
          if (svc = @service) && !svc.closed?
            stop
          end
        rescue
        end
      end
```