### PR TITLE
Fix find_elements using array and params starting with $

### DIFF
--- a/src/marionette/element.cr
+++ b/src/marionette/element.cr
@@ -139,7 +139,7 @@ module Marionette
     end
 
     def property(name)
-      execute("GetElementProperty", {"name" => name})
+      execute("GetElementProperty", {"$name" => name})
     end
 
     def attribute(name)
@@ -148,16 +148,16 @@ module Marionette
     end
 
     def dom_attribute(name)
-      execute("GetElementAttribute", {"name" => name})
+      execute("GetElementAttribute", {"$name" => name})
     end
 
     def css_property_value(name)
-      execute("GetElementValueOfCssProperty", {"name" => name})
+      execute("GetElementValueOfCssProperty", {"$name" => name})
     end
 
     def send_keys(*keys)
       text = keys.map { |k| k.is_a?(Key) ? k.value.chr : k }.join
-      execute("SendKeysToElement", {"text" => text})
+      execute("SendKeysToElement", {"$text" => text})
     end
 
     def clear

--- a/src/marionette/session.cr
+++ b/src/marionette/session.cr
@@ -452,17 +452,19 @@ module Marionette
 
       # TODO: Add support for this via Support::RelativeLocator
       # return execute_atom(:findElements, Support::RelativeLocator.new(what).as_json) if how == 'relative'
-
+      ids = Array(JSON::Any).new
       if parent
         # if parent.type == :element
           id = parent.execute("FindChildElements", { using: how, value: what.to_s })
+          ids << id
         # else :shadow_root
         #   execute("FindShadowChildElements", { id: parent_id, using: how, value: what.to_s })
       else
         id = execute("FindElements", { using: how, value: what.to_s })
+        ids << id
       end
 
-      ids.map { |id| Element.new(self, element_id_from(id)) }
+      ids.map { |id| Element.new(self, element_id_from(id[0])) }
     end
 
     # Find a child of the given element. Returns `nil` if no element with the given


### PR DESCRIPTION
Hello,

I started using marionette, but crashed when using find_elements, also I was getting empty properties from elements.
Please review this small changes I did, which made it work perfectly now.

I'm running it in crystal 1.8.2.

Thanks,