### PR TITLE
Fix up geckodriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Looking for a co-maintainer for Marionette**. If interested just respond in the issue titled "Looking for a co-maintainer".
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/watzon/marionette/specs?style=flat-square)  ![License](https://img.shields.io/github/license/watzon/marionette?style=flat-square)  ![Crystal Version](https://img.shields.io/badge/Crystal-1.0.0-%23333333?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/watzon/marionette/specs.yml?branch=master&style=flat-square)  ![License](https://img.shields.io/github/license/watzon/marionette?style=flat-square)  ![Crystal Version](https://img.shields.io/badge/Crystal-1.0.0-%23333333?style=flat-square)
 
 <div align="center">
   <img src="./assets/code.png">

--- a/src/marionette/service.cr
+++ b/src/marionette/service.cr
@@ -84,7 +84,11 @@ module Marionette
 
     def stop
       if process = @process
-        send_remote_shutdown
+        # geckodriver does not support remote shutdown, so don't try
+        # and wait for it to close gracefully.
+        unless @browser.is_a?(Browser::Firefox)
+          send_remote_shutdown
+        end
 
         begin
           process.signal(Signal::INT)

--- a/src/marionette/service.cr
+++ b/src/marionette/service.cr
@@ -62,7 +62,7 @@ module Marionette
         HTTP::Client.get(File.join(url.to_s, "shutdown"))
         0.upto(30).each do
           if open?
-            sleep 1000
+            sleep 1
           else
             break
           end


### PR DESCRIPTION
Trying out marionette for a project, I ran into some problems with geckodriver.

First off, it would just hang rather than exit. Tracked that down to a `sleep 1000`.

That cut the waiting down to 30 seconds. Apparently geckodriver doesn't support the shutdown command (https://github.com/mozilla/geckodriver/issues/771#issuecomment-307411488), so rather than waiting for it, skip directly to sending it signals.

And fix the build badge.

Doesn't solve all my problems though, seems that geckodriver spawns three other geckodriver processes when it's launched, which doesn't get killed when marionette closes it down, so I'm left with extra processes.

Experimenting a bit, I found out that killing the process group would take care of the extra geckodriver processes, but has the nasty sideeffect of also killing the Crystal process (as the geckodrivers are just added to its process group). Fixing that would involve making a special launcher for geckodriver that changes the process group before launching geckodriver, but that's a bit involved, so I can live with calling `killall geckodriver` for the time being.